### PR TITLE
RDKCOM-5324: RDKBDEV-3179: fix build for older toolchains

### DIFF
--- a/source/util_api/ccsp_msg_bus/ccsp_base_api.c
+++ b/source/util_api/ccsp_msg_bus/ccsp_base_api.c
@@ -299,11 +299,13 @@ int PSM_Set_Record_Value_rbus
 )
 {
     int ret = -1;
+    int i;
+
     CCSP_MESSAGE_BUS_INFO *bus_info = (CCSP_MESSAGE_BUS_INFO *)bus_handle;
     rbusObject_t inParams = NULL, outParams = NULL;
     rbusObject_Init(&inParams, NULL);
     rbusProperty_t list = NULL;
-    for(int i = 0; i < size; i++)
+    for(i = 0; i < size; i++)
     {
         rbusProperty_t prop;
         rbusValue_t value = NULL;
@@ -934,9 +936,11 @@ int CcspBaseIf_getParameterAttributes_rbus(
     rbusProperty_t list = NULL;
     char methodName[RBUS_MAX_NAME_LENGTH] = {0};
     parameterAttributeStruct_t **val = 0;
+    int i;
+
     *val_size = 0;
     rbusObject_Init(&inParams, NULL);
-    for(int i = 0; i < size; i++)
+    for(i = 0; i < size; i++)
     {
         rbusProperty_t prop;
         rbusProperty_Init(&prop, parameterNames[i], NULL);
@@ -978,7 +982,7 @@ int CcspBaseIf_getParameterAttributes_rbus(
             memset(val, 0, *val_size*sizeof(parameterAttributeStruct_t *));
 
             rbusObject_t child = rbusObject_GetChildren(outParams);
-            for (int i = 0; i < param_size; i++)
+            for (i = 0; i < param_size; i++)
             {
                 if (child)
                 {

--- a/source/util_api/ccsp_msg_bus/ccsp_message_bus.c
+++ b/source/util_api/ccsp_msg_bus/ccsp_message_bus.c
@@ -2333,7 +2333,7 @@ static int thread_path_message_func_rbus(const char * destination, const char * 
                    rbusValue_SetInt32(value_size, size);
                    rbusObject_SetValue(outParams, "size", value_size);
                    rbusObject_t child_obj = NULL, previous = NULL;
-                   for (int i = 0; i <size; i++)
+                   for (i = 0; i <size; i++)
                    {
                        rbusObject_t Object = NULL;
                        rbusObject_Init(&Object, val[i]->parameterName);


### PR DESCRIPTION
Reason for change:
fix build for older toolchains
Test Procedure: Sanity.
Risks: None.
Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
Priority: P1

Change-Id: I4115d783716b0a42b3c369f731936db233bfa7bd (cherry picked from commit 5eb262472c137b8d7f306c172d5823f7c569faf2)