### PR TITLE
RDKB-58521 : WAN Manager Telemetry Markers 2.0 - Phase 1

### DIFF
--- a/source/ccsp/components/include/ipc_msg.h
+++ b/source/ccsp/components/include/ipc_msg.h
@@ -190,6 +190,8 @@ typedef enum
     IPOE_MSG_IHC_ECHO_RENEW_IPV6,
     IPOE_MSG_IHC_ECHO_IPV4_UP,
     IPOE_MSG_IHC_ECHO_IPV6_UP,
+    IPOE_MSG_IHC_ECHO_IPV4_IDLE,
+    IPOE_MSG_IHC_ECHO_IPV6_IDLE,
 }ipoe_msg_type_t;
 
 typedef struct


### PR DESCRIPTION
RDKB-58521 : WAN Manager Telemetry Markers 2.0 - Phase 1

Reason for change: Implementing Telemetry support for Wanmanager. Scalable to handle further telemetry versions

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1

Change-Id: I0a4de2d79599f7a48da8d07e51443c0704e26eb6