### PR TITLE
RDKB-60325 : notify_tunnel_status failure in hotspot

### DIFF
--- a/source/ccsp/include/ccsp_base_api.h
+++ b/source/ccsp/include/ccsp_base_api.h
@@ -1275,6 +1275,11 @@ int CcspBaseIf_SendSignal(
     char *event
 );
 
+int CcspBaseIf_SendSignal_WithData_rbus(
+    void * bus_handle,
+    char *eventName,
+    char* eventData
+);
 
 int CcspBaseIf_SendSignal_WithData(
     void * bus_handle,

--- a/source/util_api/ccsp_msg_bus/ccsp_base_api.c
+++ b/source/util_api/ccsp_msg_bus/ccsp_base_api.c
@@ -2746,7 +2746,6 @@ int CcspBaseIf_SendSignal(
     return CcspBaseIf_SendSignal_rbus(bus_handle, event);
 }
 
-#if 0
 int CcspBaseIf_SendSignal_WithData_rbus(
     void * bus_handle,
     char *eventName,
@@ -2768,14 +2767,14 @@ int CcspBaseIf_SendSignal_WithData_rbus(
     event.type = RBUS_EVENT_GENERAL;
     ret = rbusEvent_Publish(bus_handle, &event);
     if(ret != RBUS_ERROR_SUCCESS) {
-        CcspTraceInfo(("provider: rbusEvent_Publish Event failed: %d\n", ret));
+        CcspTraceError(("provider: rbusEvent_Publish Event failed: %d\n", ret));
     }
-
+    else{
+        CcspTraceInfo(("provider: rbusEvent_Publish Event success: %d\n", ret));
+    }
     rbusValue_Release(value);
     return Rbus2_to_CCSP_error_mapper(ret);
 }
-
-#endif
 
 int CcspBaseIf_SendSignal_WithData(
     void * bus_handle,


### PR DESCRIPTION
Reason for change: notify_tunnel_status fails in hotspot Test Procedure: TunnelStatus should get notified
Risks: Low
Priority: P2
Signed-off-by:SupriyaShree_SS@comcast.com