### PR TITLE
RDKB-58521 : WAN Manager Telemetry Markers 2.0 - Phase 1

### DIFF
--- a/source/ccsp/components/include/ipc_msg.h
+++ b/source/ccsp/components/include/ipc_msg.h
@@ -192,6 +192,8 @@ typedef enum
     IPOE_MSG_IHC_ECHO_IPV6_UP,
     IPOE_MSG_IHC_ECHO_IPV4_IDLE,
     IPOE_MSG_IHC_ECHO_IPV6_IDLE,
+    IPOE_MSG_IHC_ECHO_IPV4_IDLE,
+    IPOE_MSG_IHC_ECHO_IPV6_IDLE,
 }ipoe_msg_type_t;
 
 typedef struct


### PR DESCRIPTION
Reason for change: Implementing Telemetry support for Wanmanager. Scalable to handle further telemetry versions.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1