### PR TITLE
RDKCOM-5604: RDKBDEV-3456, RDKBACCL-1777 Set systemd 'SyslogIdentifier' parameter

### DIFF
--- a/systemd_units/CcspCrSsp.service
+++ b/systemd_units/CcspCrSsp.service
@@ -32,7 +32,7 @@ ExecStartPre=/bin/sh -c '(/usr/ccsp/ccspSysConfigEarly.sh)'
 ExecStart=/bin/sh -c '/usr/bin/CcspCrSsp -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo 0 >> /tmp/CcspCrSsp_Restarted'
 Restart=always
-
+SyslogIdentifier=CcspCrSsp
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/CcspEthAgent.service
+++ b/systemd_units/CcspEthAgent.service
@@ -29,6 +29,7 @@ Environment="LOG4C_RCPATH=/etc"
 EnvironmentFile=/etc/device.properties
 ExecStart=/bin/sh -c '/usr/bin/CcspEthAgent -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspEthAgent" >> ${PROCESS_RESTART_LOG}'
+SyslogIdentifier=CcspEthAgent
 Restart=always
 
 

--- a/systemd_units/CcspLMLite.service
+++ b/systemd_units/CcspLMLite.service
@@ -29,6 +29,7 @@ Environment="LOG4C_RCPATH=/etc"
 EnvironmentFile=/etc/device.properties
 ExecStart=/bin/sh -c '/usr/bin/CcspLMLite -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspLMLite" >> ${PROCESS_RESTART_LOG}'
+SyslogIdentifier=CcspLMLite
 Restart=always
 
 

--- a/systemd_units/CcspPandMSsp.service
+++ b/systemd_units/CcspPandMSsp.service
@@ -33,6 +33,7 @@ ExecStartPre=/bin/sh -c '(/usr/ccsp/pam/GwProvCheck.sh)'
 ExecStart=/bin/sh -c '/usr/bin/CcspPandMSsp -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspPandMSsp" >> ${PROCESS_RESTART_LOG}'
 ExecStartPost=/bin/sh -c '(/usr/ccsp/ccspPAMCPCheck.sh)'
+SyslogIdentifier=CcspPandMSsp
 Restart=always
 
 

--- a/systemd_units/CcspTandDSsp.service
+++ b/systemd_units/CcspTandDSsp.service
@@ -30,7 +30,7 @@ WorkingDirectory=/usr/ccsp/tad
 ExecStart=/bin/sh -c '/usr/bin/CcspTandDSsp -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspTandDSsp" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=CcspTandDSsp
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/CcspTr069PaSsp.service
+++ b/systemd_units/CcspTr069PaSsp.service
@@ -31,6 +31,7 @@ WorkingDirectory=/usr/ccsp/tr069pa
 ExecStartPre=/bin/sh -c 'val=`syscfg get EnableTR69Binary`; if [ "$val" == "false" ]; then `systemctl stop CcspTr069PaSsp`; fi'
 ExecStart=/bin/sh -c '/usr/bin/CcspTr069PaSsp -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspTr069PaSsp" >> ${PROCESS_RESTART_LOG}'
+SyslogIdentifier=CcspTr069PaSsp
 Restart=always
 SuccessExitStatus=SIGTERM
 

--- a/systemd_units/CcspXdnsSsp.service
+++ b/systemd_units/CcspXdnsSsp.service
@@ -30,7 +30,7 @@ WorkingDirectory=/usr/ccsp/xdns
 ExecStart=/bin/sh -c '/usr/bin/CcspXdnsSsp -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting CcspXdnsSsp" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=CcspXdnsSsp
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/ProcessResetDetect.service
+++ b/systemd_units/ProcessResetDetect.service
@@ -22,4 +22,4 @@ Description=Process Restart Service
 [Service]
 Type=simple
 ExecStart=/bin/sh -c '(/usr/ccsp/ProcessResetCheck.sh)'
-
+SyslogIdentifier=ProcessResetDetect

--- a/systemd_units/PsmSsp.service
+++ b/systemd_units/PsmSsp.service
@@ -35,7 +35,7 @@ ExecStart=/bin/sh -c '/usr/bin/PsmSsp -subsys $Subsys'
 ExecStartPost=/bin/sh -c '(/etc/migration_to_psm.sh)'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting PsmSsp" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=PsmSsp
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/RdkFwUpgradeManager.service
+++ b/systemd_units/RdkFwUpgradeManager.service
@@ -28,7 +28,7 @@ WorkingDirectory=/usr/rdk/fwupgrademanager
 ExecStart=/usr/bin/fwupgrademanager -subsys $Subsys
 ExecStop=/bin/sh -c 'echo "`date`: Stopping/Restarting RdkFwUpgradeManager"'
 Restart=always
-
+SyslogIdentifier=RdkFwUpgradeManager
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/RdkVlanManager.service
+++ b/systemd_units/RdkVlanManager.service
@@ -30,7 +30,7 @@ WorkingDirectory=/usr/rdk/vlanmanager
 ExecStart=/usr/bin/VlanManager -subsys $Subsys
 ExecStop=/bin/sh -c 'echo "`date`: Stopping/Restarting VlanManager" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=RdkVlanManager
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/RdkWanManager.service
+++ b/systemd_units/RdkWanManager.service
@@ -33,7 +33,7 @@ ExecStartPre=/bin/sh -c '(/usr/ccsp/utopiaInitCheck.sh)'
 ExecStart=/usr/rdk/wanmanager/wanmanager -subsys $Subsys
 ExecStop=/bin/sh -c 'echo "`date`: Stopping/Restarting RdkWanManager" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=RdkWanManager
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/notifyComp.service
+++ b/systemd_units/notifyComp.service
@@ -30,7 +30,7 @@ EnvironmentFile=/etc/device.properties
 ExecStart=/bin/sh -c '/usr/bin/notify_comp -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting notify_comp" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=notifyComp
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/parodus.service
+++ b/systemd_units/parodus.service
@@ -30,7 +30,7 @@ ExecStartPre=/usr/bin/parodusStart
 ExecStart=/bin/sh -c 'source /tmp/parodusCmd.cmd'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting parodus" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=parodus
 
 [Install]
 WantedBy=wan-initialized.target

--- a/systemd_units/rdkbLogMonitor.service
+++ b/systemd_units/rdkbLogMonitor.service
@@ -29,7 +29,7 @@ ExecStart=/bin/sh -c 'val=$(syscfg get RdkbLogCronEnable); if [ "$val" = "true" 
 ExecStop=/bin/sh -c 'echo "==> sync logs to nvram before reboot" >>/rdklogs/logs/Consolelog.txt.0'
 ExecStop=/bin/sh -c 'source /rdklogger/logfiles.sh;syncLogs_nvram2 "reboot"'
 RemainAfterExit=yes
-
+SyslogIdentifier=rdkbLogMonitor
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd_units/rfc.service
+++ b/systemd_units/rfc.service
@@ -26,7 +26,7 @@ EnvironmentFile=/etc/device.properties
 ExecStart=/bin/sh -c 'echo "Enable RFC feature" >> ${PARODUS_START_LOG_FILE}'
 ExecStart=/bin/sh -c '/lib/rdk/rfc.service &'
 RemainAfterExit=yes
-
+SyslogIdentifier=rfc
 
 [Install]
 WantedBy=wan-initialized.target

--- a/systemd_units/webconfig.service
+++ b/systemd_units/webconfig.service
@@ -28,7 +28,7 @@ EnvironmentFile=/etc/device.properties
 ExecStart=/usr/bin/webconfig
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting webconfig" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=webconfig
 
 [Install]
 WantedBy=wan-initialized.target

--- a/systemd_units/webpa.service
+++ b/systemd_units/webpa.service
@@ -30,7 +30,7 @@ WorkingDirectory=/usr/ccsp/webpa
 ExecStart=/bin/sh -c 'source /etc/utopia/service.d/log_env_var.sh;/usr/bin/webpa -subsys $Subsys'
 ExecStopPost=/bin/sh -c 'echo "`date`: Stopping/Restarting webpa" >> ${PROCESS_RESTART_LOG}'
 Restart=always
-
+SyslogIdentifier=webpa
 
 [Install]
 WantedBy=wan-initialized.target


### PR DESCRIPTION
RDKBACCL-1777 : Set systemd 'SyslogIdentifier' parameter

Reason for change: syslog / journal entries in systemd log can no longer be differentiated between services
Test Procedure: Build RDK image and verify output with `journalctl -f` (see details below), the process name should match the originating service (like CcspPandM, CcspEthAgent) and NOT `sh`
Risks: Low 
Priority: P2

------------------------------------

This [patch](https://github.com/rdkcentral/meta-rdk-bsp-arm/blob/develop/meta-rdk-broadband/recipes-ccsp/ccsp/files/0001-service-set-systemd-SyslogIdentifier.patch) has been part of [meta-rdk-bsp-arm](https://github.com/rdkcentral/meta-rdk-bsp-arm) for a while and I believe it would be beneficial to upstream it.

A previous changeset made all services invoked via the "/bin/sh -c '(...)'" pattern, which causes all syslog/journalctl entries to have the `sh` process name.

This can cause a lot of confusion when viewing the system log via journalctl:
```
sh[5613]: Fetching values to form parodus command line arguments
sh[5151]: result =
sh[5151]: result = rdkb-generic-broadband-image_rdkb-2025q1-kirkstone_20250606001224
sh[5613]: Framing command for parodus
sh[5613]: Starting parodus with the following arguments
sh[5613]: ModelName=RPI  SerialNumber=  Manufacturer=Traverse  HW_MAC=00:0a:fa:24:29:5d ...
sh[5808]: rdk_dyn_log_initg_dl_socket = 3 __progname = parodus
sh[5551]: Conf file /etc/debug.ini open success
sh[5551]: rdk_dyn_log_initg_dl_socket = 3 __progname = CcspTandDSsp
sh[5551]: rdk_logger_init /etc/debug.ini Already Stack Level Logging processed... not processing again.
sh[5551]: ****LOADING DM LIBRARY***************
sh[5573]: CosaEthInferface initialization done!
sh[5573]: CcspHalExtSw_getAssociatedDevice not implemented on generic arm platforms yet
```
In the above output there is a mix of CcspPandMSsp, Parodus and CcspEthAgent, which is very confusing.

Setting the SyslogIdentifier in each systemd unit file allows the correct ident to be applied to the log entries:
```
PsmSsp[1820]: rdk_dyn_log_initg_dl_socket = 3 __progname = PsmSsp
CcspEthAgent[3754]: CcspHalExtSw_getAssociatedDevice not implemented on generic arm platforms yet
```

edited to add (2026-07-16): while there are many other service files in the `systemd_units` folder, we have only modified the ones we are sure we are using