### PR TITLE
RDKCOM-5595: RDKBDEV-3450 The CM is not updated with DNS Name (Option15), instead utopia.net is displayed in LAN side provisioning.

### DIFF
--- a/source/ccsp/components/include/ipc_msg.h
+++ b/source/ccsp/components/include/ipc_msg.h
@@ -131,6 +131,7 @@ typedef struct _ipc_dhcpv4_data_t
     char ip[BUFLEN_32];                /** New IP address, if addressAssigned==TRUE */
     char mask[BUFLEN_32];              /** New netmask, if addressAssigned==TRUE */
     char gateway[BUFLEN_32];           /** New gateway, if addressAssigned==TRUE */
+    char domain[BUFLEN_64];            /** New domain name, if addressAssigned==TRUE */
     char dnsServer[BUFLEN_64];         /** New dns Server, if addressAssigned==TRUE */
     char dnsServer1[BUFLEN_64];        /** New dns Server, if addressAssigned==TRUE */
     char dhcpcInterface[BUFLEN_64];    /** Dhcp interface name */


### PR DESCRIPTION
Reason for change: Added provisioning to fetch the DHCPv4 Option 15 (Domain Name) value via udhcpc and forward it to the WAN Manager. The WAN Manager then sets the corresponding sysevent, enabling dnsmasq to propagate the domain name to LAN clients.

Risks: Low