### PR TITLE
RDKB-65870: Fix memory leak in dmcli get call

### DIFF
--- a/source/util_api/ccsp_msg_bus/ccsp_base_api.c
+++ b/source/util_api/ccsp_msg_bus/ccsp_base_api.c
@@ -693,7 +693,10 @@ int CcspBaseIf_getParameterValues_rbus(
             {
                 size = 1;
                 rbusProperty_Init(&outputVals, parameterNames[0], getVal);
-                /* Do NOT release getVal here. getVal is owned and allocated by rbus infrastructure and rbusProperty_Init takes a reference to it. */
+                /* rbus_get transfers ownership of getVal (refCount 1) to us, and
+                 * rbusProperty_Init takes its own additional reference. Release our
+                 * reference now so that releasing the property list frees getVal. */
+                rbusValue_Release(getVal);
             }
         }
         else


### PR DESCRIPTION
Reason for change: To fix memory leak due to incorrect usage of rbus library APIs

Test Procedure: Execute 'dmcli eRT getv Device.Hosts.Host.' multiple times 
and confirm gradual increase in RSS memory of CcspLMLite process is NOT observed.

Risks: Low
Priority: P1