### PR TITLE
RDKB-64747: CcspPandM component is crashing on Device.Time.Status subscription

### DIFF
--- a/source/util_api/ccsp_msg_bus/ccsp_rbus_value_change.c
+++ b/source/util_api/ccsp_msg_bus/ccsp_rbus_value_change.c
@@ -318,6 +318,13 @@ static void* rbusValueChange_pollingThreadFunc(void *userData)
 
             if(val)
             {
+                if((!rec->value) || (!val[0]->parameterValue))
+                {
+                    CcspTraceError (("%s: previous value or current value is NULL\n", __FUNCTION__));
+                    free_parameterValStruct_t(rec->handle, 1, val);
+                    continue;
+                }
+
                 if(strcmp(rec->value, val[0]->parameterValue) != 0)
                 {
                     int filterResult = -1;
@@ -422,7 +429,10 @@ int Ccsp_RbusValueChange_Subscribe(
         val = rbusValueChange_GetParameterValue(rec);
         if(val)
         {
-            rec->value = strdup(val[0]->parameterValue);
+            if(val[0]->parameterValue)
+            {
+                rec->value = strdup(val[0]->parameterValue);
+            }
             free_parameterValStruct_t(rec->handle, 1, val);
         }
 


### PR DESCRIPTION
RDKB-64747: CcspPandM component is crashing on Device.Time.Status subscription

Reason for change: To fix PandM crash observed when subscribing to Device.Time.Status baked with a NULL value that is out of range from syscfg parameter ntp_status

Test Procedure: Execute 'syscfg set ntp_status 0' and then subscribe to the corresponding DM with command
'rbuscli sub Device.Time.Status' and confirm CcspPandM process is NOT crashed.

Risks: Low
Priority: P1